### PR TITLE
remove closure from config file

### DIFF
--- a/src/Config/midia.php
+++ b/src/Config/midia.php
@@ -6,12 +6,6 @@ return [
     'directory_name' => 'media',
     'url_prefix' => 'media',
     'prefix' => 'midia',
-
-    // 404
-    '404' => function() {
-    	return abort(404);
-    },
-    
     // Multiple target directories
     'directories' => [
     	// Examples:

--- a/src/Route/web.php
+++ b/src/Route/web.php
@@ -37,7 +37,7 @@ Route::group(['prefix' => config('midia.url_prefix', 'media')], function() {
     }
 
 
-    if(!File::exists($path)) return config('midia.404')();
+    if(!File::exists($path)) return abort(404);
 
     $file = File::get($path);
     $type = File::mimeType($path);


### PR DESCRIPTION
When installed in Laravel 5.7, the config file can't be cached because of the closure in the config file. This fixes it.