### PR TITLE
added missing mime types for image checks

### DIFF
--- a/src/Controller/MidiaController.php
+++ b/src/Controller/MidiaController.php
@@ -145,9 +145,13 @@ class MidiaController extends Controller {
         // Resize
         $is_image = [
             'image/jpg',
+            'image/jpeg',
+            'image/pjpeg',
             'image/png',
+            'image/x-png',
             'image/gif',
-            'image/webp'
+            'image/webp',
+            'image/x-webp'
         ];
         if(in_array(mime_content_type($this->directory . '/' . $fileName), $is_image)) {
             $this->_resize($fileName);


### PR DESCRIPTION
The thumbnails weren't created for some missing mime types included in intervention/image but not in midia. This fixes it.