### PR TITLE
Fixed the time since upload showing 12h difference

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -37,7 +37,7 @@ if (!function_exists('midia_time_elapsed')) {
      */
     function midia_time_elapsed($datetime, $full=false)
     {
-        $datetime = date('Y-m-d h:i:s', $datetime);
+        $datetime = date('Y-m-d H:i:s', $datetime);
         $now = new DateTime;
         $ago = new DateTime($datetime);
         $diff = $now->diff($ago);


### PR DESCRIPTION
Changing the format to "H" turns out to fix an issue when a recent file show it was uploaded 12 hours ago.